### PR TITLE
Implement config and database setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://user:password@localhost:5432/enel

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ The architecture and best practices are based on the blueprint in [`init.txt`](i
 
 1. Install [Node.js](https://nodejs.org/) v20 or later.
 2. Clone this repository and run `npm install`.
-3. Create a `.env` file with your PostgreSQL connection string and API keys.
-4. Run `npm start` to launch the placeholder script.
+3. Copy `.env.example` to `.env` and update the PostgreSQL connection string and any API keys.
+4. Edit `config.json` if you want to change non-secret settings.
+5. Run `npm start` to launch the app and create the database tables if needed.
 
 ## Roadmap
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "asrEngine": "local",
+  "llmEngine": "local",
+  "historyLimit": 10,
+  "baseFolder": "data"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,175 @@
+{
+  "name": "enel",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "enel",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.3.1",
+        "pg": "^8.11.5"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "pg": "^8.11.5"
+  }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const defaults = {
+  asrEngine: 'local',
+  llmEngine: 'local',
+  historyLimit: 10,
+  baseFolder: 'data'
+};
+
+let fileConfig = {};
+try {
+  const configPath = path.join(__dirname, '..', 'config.json');
+  const raw = fs.readFileSync(configPath, 'utf8');
+  fileConfig = JSON.parse(raw);
+} catch (err) {
+  console.warn('config.json not found or invalid, using defaults');
+}
+
+module.exports = {
+  ...defaults,
+  ...fileConfig,
+  databaseUrl: process.env.DATABASE_URL
+};

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,25 @@
+const { Pool } = require('pg');
+const config = require('./config');
+
+const pool = new Pool({
+  connectionString: config.databaseUrl
+});
+
+pool.on('error', (err) => {
+  console.error('Unexpected database error', err);
+});
+
+async function testConnection() {
+  try {
+    await pool.query('SELECT 1');
+    console.log('Connected to PostgreSQL');
+  } catch (err) {
+    console.error('PostgreSQL connection error:', err.message);
+    throw err;
+  }
+}
+
+module.exports = {
+  pool,
+  testConnection
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,20 @@
-console.log('WhatsApp AI Auto-Responder initialized');
+const config = require('./config');
+const db = require('./db');
+const setupDb = require('./setupDb');
+
+async function start() {
+  console.log('Configuration loaded:', {
+    asrEngine: config.asrEngine,
+    llmEngine: config.llmEngine,
+    historyLimit: config.historyLimit,
+    baseFolder: config.baseFolder,
+    databaseUrl: config.databaseUrl ? 'present' : 'missing'
+  });
+  await db.testConnection();
+  await setupDb();
+  console.log('WhatsApp AI Auto-Responder initialized');
+}
+
+start().catch(err => {
+  console.error('Startup failed', err);
+});

--- a/src/setupDb.js
+++ b/src/setupDb.js
@@ -1,0 +1,53 @@
+const { pool } = require('./db');
+
+async function setup() {
+  const queries = [
+    `CREATE TABLE IF NOT EXISTS Contacts (
+      id TEXT PRIMARY KEY,
+      name TEXT
+    )`,
+    `CREATE TABLE IF NOT EXISTS Messages (
+      id TEXT PRIMARY KEY,
+      chatId TEXT REFERENCES Contacts(id),
+      fromMe BOOLEAN,
+      timestamp BIGINT,
+      body TEXT
+    )`,
+    `CREATE TABLE IF NOT EXISTS Attachments (
+      id SERIAL PRIMARY KEY,
+      messageId TEXT REFERENCES Messages(id),
+      filePath TEXT
+    )`,
+    `CREATE TABLE IF NOT EXISTS Transcripts (
+      id SERIAL PRIMARY KEY,
+      messageId TEXT REFERENCES Messages(id),
+      transcriptText TEXT,
+      asrEngine TEXT
+    )`,
+    `CREATE TABLE IF NOT EXISTS AiReplies (
+      id SERIAL PRIMARY KEY,
+      originalMessageId TEXT REFERENCES Messages(id),
+      draftText TEXT,
+      status TEXT,
+      sentMessageId TEXT
+    )`
+  ];
+
+  for (const q of queries) {
+    try {
+      await pool.query(q);
+    } catch (err) {
+      console.error('Error executing query:', q, err.message);
+      throw err;
+    }
+  }
+  console.log('Database schema ensured');
+}
+
+if (require.main === module) {
+  setup()
+    .then(() => process.exit(0))
+    .catch(() => process.exit(1));
+}
+
+module.exports = setup;


### PR DESCRIPTION
## Summary
- set up configuration loader using `.env` and `config.json`
- create database connection module with pg
- add setup script for Contacts, Messages, Attachments, Transcripts and AiReplies tables
- update start script to load configuration, test DB connection and run setup
- document new setup steps in README
- provide example environment file and default config

## Testing
- `npm install`
- `npm start` *(fails: ECONNREFUSED since Postgres isn't running)*

------
https://chatgpt.com/codex/tasks/task_e_6860802f92e08326a017589b867f69cc