### PR TITLE
Implement media download and storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ logs/
 *.log
 .wwebjs_auth
 .wwebjs_cache
+data/


### PR DESCRIPTION
## Summary
- implement media download and attachment storage
- ignore `data/` folder in git

## Testing
- `npm start` *(fails: PostgreSQL connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68611bcde70c83269f779cb28a41aa42