### PR TITLE
Implement conversation history retrieval

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -1,0 +1,19 @@
+const { pool } = require('./db');
+const config = require('./config');
+
+async function getHistory(chatId, limit = config.historyLimit) {
+  if (!chatId) throw new Error('chatId required');
+  const res = await pool.query(
+    `SELECT m.id, m.fromMe, m.timestamp,
+            COALESCE(t.transcriptText, m.body) AS text
+     FROM Messages m
+     LEFT JOIN Transcripts t ON m.id = t.messageId
+     WHERE m.chatId = $1
+     ORDER BY m.timestamp DESC
+     LIMIT $2`,
+    [chatId, limit]
+  );
+  return res.rows;
+}
+
+module.exports = { getHistory };


### PR DESCRIPTION
## Summary
- add `getHistory` function to fetch recent messages for a chat

## Testing
- `npm install`
- `node - <<'EOF'
const {getHistory}=require('./src/history');
getHistory('123').then(console.log).catch(console.error);
EOF`
- `npm start` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6861424b6b3083268ae67d87ec82bcde