### PR TITLE
Implement send message module

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This functionality is implemented in `src/confirm.js`.
 - **Guidelines:** Only send after explicit approval.
 - **Expectations:** Sent messages appear in WhatsApp and the database reflects the action.
 - **Testing:** Approve a reply and confirm delivery plus database update.
+This functionality is implemented in `src/send.js`.
 
 ### Task 13: Error handling and retry logic
 - **Input:** Failures from network requests or database operations.

--- a/src/send.js
+++ b/src/send.js
@@ -1,0 +1,33 @@
+const { pool } = require('./db');
+
+async function logAiReply(originalMessageId, draftText, status, sentMessageId) {
+  try {
+    await pool.query(
+      `INSERT INTO AiReplies(originalMessageId, draftText, status, sentMessageId)
+       VALUES ($1, $2, $3, $4)`,
+      [originalMessageId, draftText, status, sentMessageId]
+    );
+  } catch (err) {
+    console.error('Failed to log AiReply', err.message);
+  }
+}
+
+async function sendMessage(client, chatId, text, originalMessageId) {
+  if (!client || !chatId || !text) {
+    throw new Error('client, chatId and text are required');
+  }
+  try {
+    const sent = await client.sendMessage(chatId, text);
+    const sentId = sent.id?._serialized || sent.id;
+    await logAiReply(originalMessageId, text, 'sent', sentId);
+    console.log('Message sent with id', sentId);
+    return sent;
+  } catch (err) {
+    await logAiReply(originalMessageId, text, 'failed', null);
+    console.error('Failed to send message', err.message);
+    return null;
+  }
+}
+
+module.exports = { sendMessage };
+


### PR DESCRIPTION
## Summary
- implement send message helper and DB logging
- document module location for Task 12

## Testing
- `node --check src/send.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68615b0ea6cc8326ac09915c90c937fd