### PR TITLE
Fix history retrieval for prompts

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -3,17 +3,23 @@ const config = require('./config');
 
 async function getHistory(chatId, limit = config.historyLimit) {
   if (!chatId) throw new Error('chatId required');
-  const res = await pool.query(
-    `SELECT m.id, m.fromMe, m.timestamp,
-            COALESCE(t.transcriptText, m.body) AS text
-     FROM Messages m
-     LEFT JOIN Transcripts t ON m.id = t.messageId
-     WHERE m.chatId = $1
-     ORDER BY m.timestamp DESC
-     LIMIT $2`,
-    [chatId, limit]
-  );
-  return res.rows;
+
+  const baseQuery = `SELECT m.id, m.fromMe, m.timestamp,
+                            COALESCE(t.transcriptText, m.body) AS text
+                     FROM Messages m
+                     LEFT JOIN Transcripts t ON m.id = t.messageId
+                     WHERE m.chatId = $1 AND m.fromMe = $2
+                     ORDER BY m.timestamp DESC
+                     LIMIT $3`;
+
+  const [mine, theirs] = await Promise.all([
+    pool.query(baseQuery, [chatId, true, limit]),
+    pool.query(baseQuery, [chatId, false, limit])
+  ]);
+
+  const combined = [...mine.rows, ...theirs.rows];
+  combined.sort((a, b) => a.timestamp - b.timestamp);
+  return combined;
 }
 
 module.exports = { getHistory };

--- a/src/send.js
+++ b/src/send.js
@@ -12,6 +12,26 @@ async function logAiReply(originalMessageId, draftText, status, sentMessageId) {
   }
 }
 
+async function storeSentMessage(sent, chatId, text) {
+  if (!sent || !chatId) return;
+  const id = sent.id?._serialized || sent.id;
+  const timestamp = sent.timestamp || Math.floor(Date.now() / 1000);
+  try {
+    await pool.query(
+      'INSERT INTO Contacts(id) VALUES($1) ON CONFLICT (id) DO NOTHING',
+      [chatId]
+    );
+    await pool.query(
+      `INSERT INTO Messages(id, chatId, fromMe, timestamp, body)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (id) DO NOTHING`,
+      [id, chatId, true, timestamp, text]
+    );
+  } catch (err) {
+    console.error('Failed to store sent message', err.message);
+  }
+}
+
 async function sendMessage(client, chatId, text, originalMessageId) {
   if (!client || !chatId || !text) {
     throw new Error('client, chatId and text are required');
@@ -19,6 +39,7 @@ async function sendMessage(client, chatId, text, originalMessageId) {
   try {
     const sent = await client.sendMessage(chatId, text);
     const sentId = sent.id?._serialized || sent.id;
+    await storeSentMessage(sent, chatId, text);
     await logAiReply(originalMessageId, text, 'sent', sentId);
     console.log('Message sent with id', sentId);
     return sent;

--- a/src/waClient.js
+++ b/src/waClient.js
@@ -123,11 +123,11 @@ async function handleIncoming(client, msg) {
   const filePath = await storeMedia(msg);
   await transcribeAndStore(msg, filePath);
 
-  const historyRecords = await getHistory(msg.from, config.historyLimit + 1);
+  const historyRecords = await getHistory(msg.from, config.historyLimit);
   if (historyRecords.length === 0) return;
 
-  const [latest, ...rest] = historyRecords;
-  const history = rest.reverse();
+  const latest = historyRecords[historyRecords.length - 1];
+  const history = historyRecords.slice(0, -1);
   const newText = latest.text || '';
 
   const draft = await draftReply(


### PR DESCRIPTION
## Summary
- fetch outgoing messages along with incoming ones for history
- sort history chronologically and include last incoming message separately

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68619ac1cd00832685ca8e67b7d1099c