### PR TITLE
Implement history fetch script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Development Guidelines
+
+- Keep code modular and use CommonJS modules.
+- Format code with 2-space indentation.
+- Place new documentation under `docs/`.
+- After making changes, run `node src/setupDb.js` followed by `npm start` to ensure the app boots.
+- If you need a PostgreSQL instance quickly, you can start one with Docker:
+  `docker run --name enel-postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d postgres`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ The architecture and best practices are based on the blueprint in [`init.txt`](i
 3. Copy `.env.example` to `.env` and update the PostgreSQL connection string and any API keys.
 4. Edit `config.json` if you want to change non-secret settings such as the LLM
    engine, model, or persona string.
-5. Run `npm start` to launch the app and create the database tables if needed.
+5. If you don't have PostgreSQL installed, you can run a temporary instance using Docker:
+   `docker run --name enel-postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d postgres`
+6. Run `npm start` to launch the app and create the database tables if needed.
 
 ## Roadmap
 

--- a/docs/fetch_messages_plan.md
+++ b/docs/fetch_messages_plan.md
@@ -1,0 +1,25 @@
+# Fetching Historical WhatsApp Messages
+
+This script uses `chat.fetchMessages()` from **whatsapp-web.js** to backfill the database with recent chat history. WhatsApp Web only loads messages in small batches, so the script mimics scrolling and cannot pull the full history at once.
+
+## Basic Flow
+
+1. Connect to WhatsApp using `LocalAuth`.
+2. Iterate over all chats that are not groups.
+3. For each chat, fetch a limited number of past messages (default 200).
+4. Save each message and any media to the database using the same logic as the `message_create` listener.
+5. Pause a few seconds between chats to reduce ban risk.
+
+## Usage Recommendations
+
+- Run the script sparingly. Fetching large histories frequently can trigger account bans.
+- Prioritise important chats rather than fetching every conversation.
+- Combine this one-time backfill with the realtime `message_create` listener to capture new messages going forward.
+
+## Weekly Execution
+
+On application start (`npm start`), the app checks when the history fetch last ran. If more than a week has passed, it will perform the fetch again and update the timestamp in the database.
+
+## Risks
+
+Fetching thousands of messages is resource intensive and may be flagged by WhatsApp. Always keep the fetch limit conservative and include delays.

--- a/src/fetchHistory.js
+++ b/src/fetchHistory.js
@@ -1,0 +1,55 @@
+const { pool } = require('./db');
+const { logMessageDetails } = require('./messageLogger');
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function shouldFetch() {
+  const res = await pool.query('SELECT last_fetch FROM FetchMeta LIMIT 1');
+  if (res.rowCount === 0) return true;
+  const last = res.rows[0].last_fetch;
+  return Date.now() - new Date(last).getTime() > 7 * 24 * 60 * 60 * 1000;
+}
+
+async function updateLastFetch() {
+  const now = new Date();
+  const res = await pool.query('SELECT last_fetch FROM FetchMeta');
+  if (res.rowCount === 0) {
+    await pool.query('INSERT INTO FetchMeta(last_fetch) VALUES ($1)', [now]);
+  } else {
+    await pool.query('UPDATE FetchMeta SET last_fetch=$1', [now]);
+  }
+}
+
+async function fetchHistory(client, limit = 200) {
+  const chats = await client.getChats();
+  console.log(`Found ${chats.length} chats. Starting fetch...`);
+  for (const chat of chats) {
+    if (chat.isGroup) continue;
+    console.log(`Fetching history for: ${chat.name || chat.id._serialized}`);
+    const messages = await chat.fetchMessages({ limit });
+    for (const msg of messages) {
+      await logMessageDetails(msg);
+    }
+    console.log(`-> Processed ${messages.length} messages for ${chat.name || chat.id._serialized}`);
+    await sleep(5000);
+  }
+}
+
+async function maybeFetchHistory(client) {
+  if (!(await shouldFetch())) {
+    console.log('History fetch skipped (recently run)');
+    return;
+  }
+  console.log('Starting history fetch...');
+  try {
+    await fetchHistory(client);
+    await updateLastFetch();
+    console.log('History fetch completed.');
+  } catch (err) {
+    console.error('History fetch failed', err);
+  }
+}
+
+module.exports = { maybeFetchHistory };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const config = require('./config');
 const db = require('./db');
 const setupDb = require('./setupDb');
 const initWhatsApp = require('./waClient');
+const { maybeFetchHistory } = require('./fetchHistory');
 
 async function start() {
   console.log('Configuration loaded:', {
@@ -13,7 +14,8 @@ async function start() {
   });
   await db.testConnection();
   await setupDb();
-  await initWhatsApp();
+  const client = await initWhatsApp();
+  await maybeFetchHistory(client);
   console.log('WhatsApp AI Auto-Responder initialized');
 }
 

--- a/src/messageLogger.js
+++ b/src/messageLogger.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const mime = require('mime');
+const { pool } = require('./db');
+const config = require('./config');
+const asr = require('./asr');
+
+async function storeMessage(msg) {
+  if (!msg || !msg.id) return;
+  const id = msg.id._serialized || msg.id;
+  const chatId = msg.fromMe ? msg.to : msg.from;
+  const timestamp = msg.timestamp;
+  const body = msg.body;
+
+  try {
+    await pool.query(
+      'INSERT INTO Contacts(id) VALUES($1) ON CONFLICT (id) DO NOTHING',
+      [chatId]
+    );
+    await pool.query(
+      `INSERT INTO Messages(id, chatId, fromMe, timestamp, body)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (id) DO NOTHING`,
+      [id, chatId, msg.fromMe, timestamp, body]
+    );
+  } catch (err) {
+    console.error('Failed to store message', err.message);
+  }
+}
+
+async function storeMedia(msg) {
+  if (!msg.hasMedia) return null;
+  const id = msg.id._serialized || msg.id;
+
+  try {
+    const media = await msg.downloadMedia();
+    if (!media) {
+      console.warn('No media content for message', id);
+      return null;
+    }
+
+    const contact = msg.fromMe ? msg.to : msg.from;
+    const date = new Date(msg.timestamp * 1000).toISOString().slice(0, 10);
+    const dir = path.join(config.baseFolder, contact, date);
+    await fs.promises.mkdir(dir, { recursive: true });
+
+    const extFromMime = media.mimetype ? mime.getExtension(media.mimetype) : '';
+    const extFromName = media.filename ? path.extname(media.filename).slice(1) : '';
+    const ext = extFromMime || extFromName;
+    const filename = `${msg.timestamp}_${id}${ext ? '.' + ext : ''}`;
+    const filePath = path.resolve(dir, filename);
+
+    await fs.promises.writeFile(filePath, media.data, 'base64');
+
+    await pool.query(
+      'INSERT INTO Attachments(messageId, filePath) VALUES ($1, $2)',
+      [id, filePath]
+    );
+    console.log('Saved media to', filePath);
+    return filePath;
+  } catch (err) {
+    console.error('Failed to store media', err.message);
+    return null;
+  }
+}
+
+async function transcribeAndStore(msg, filePath) {
+  if (!filePath) return;
+  const id = msg.id._serialized || msg.id;
+  const result = await asr.transcribe(filePath);
+  if (!result || !result.text) return;
+  const conf = result.confidence ?? 1;
+  if (conf < config.transcriptThreshold) return;
+  try {
+    await pool.query(
+      'INSERT INTO Transcripts(messageId, transcriptText, asrEngine) VALUES ($1, $2, $3)',
+      [id, result.text, config.asrEngine]
+    );
+    console.log('Stored transcript for', id);
+  } catch (err) {
+    console.error('Failed to store transcript', err.message);
+  }
+}
+
+async function logMessageDetails(msg) {
+  await storeMessage(msg);
+  const filePath = await storeMedia(msg);
+  await transcribeAndStore(msg, filePath);
+}
+
+module.exports = { logMessageDetails };

--- a/src/setupDb.js
+++ b/src/setupDb.js
@@ -30,6 +30,9 @@ async function setup() {
       draftText TEXT,
       status TEXT,
       sentMessageId TEXT
+    )`,
+    `CREATE TABLE IF NOT EXISTS FetchMeta (
+      last_fetch TIMESTAMPTZ
     )`
   ];
 

--- a/src/waClient.js
+++ b/src/waClient.js
@@ -1,98 +1,13 @@
 const { Client, LocalAuth } = require('whatsapp-web.js');
 const qrcode = require('qrcode-terminal');
-const fs = require('fs');
-const path = require('path');
-const mime = require('mime');
-const { pool } = require('./db');
 const config = require('./config');
-const asr = require('./asr');
 const { getHistory } = require('./history');
 const { draftReply } = require('./llm');
 const confirmDraft = require('./confirm');
 const { sendMessage } = require('./send');
+const { logMessageDetails } = require('./messageLogger');
 
-async function storeMessage(msg) {
-  if (!msg || !msg.id) return;
-  const id = msg.id._serialized || msg.id;
-  const chatId = msg.fromMe ? msg.to : msg.from;
-  const timestamp = msg.timestamp;
-  const body = msg.body;
-
-  try {
-    await pool.query(
-      'INSERT INTO Contacts(id) VALUES($1) ON CONFLICT (id) DO NOTHING',
-      [chatId]
-    );
-    await pool.query(
-      `INSERT INTO Messages(id, chatId, fromMe, timestamp, body)
-       VALUES ($1, $2, $3, $4, $5)
-       ON CONFLICT (id) DO NOTHING`,
-      [id, chatId, msg.fromMe, timestamp, body]
-    );
-  } catch (err) {
-    console.error('Failed to store message', err.message);
-  }
-}
-
-async function storeMedia(msg) {
-  if (!msg.hasMedia) return null;
-  const id = msg.id._serialized || msg.id;
-
-  try {
-    const media = await msg.downloadMedia();
-    if (!media) {
-      console.warn('No media content for message', id);
-      return;
-    }
-
-    const contact = msg.fromMe ? msg.to : msg.from;
-    const date = new Date(msg.timestamp * 1000).toISOString().slice(0, 10);
-    const dir = path.join(config.baseFolder, contact, date);
-    await fs.promises.mkdir(dir, { recursive: true });
-
-    const extFromMime = media.mimetype ? mime.getExtension(media.mimetype) : '';
-    const extFromName = media.filename ? path.extname(media.filename).slice(1) : '';
-    const ext = extFromMime || extFromName;
-    const filename = `${msg.timestamp}_${id}${ext ? '.' + ext : ''}`;
-    const filePath = path.resolve(dir, filename);
-
-    await fs.promises.writeFile(filePath, media.data, 'base64');
-
-    await pool.query(
-      'INSERT INTO Attachments(messageId, filePath) VALUES ($1, $2)',
-      [id, filePath]
-    );
-    console.log('Saved media to', filePath);
-    return filePath;
-  } catch (err) {
-    console.error('Failed to store media', err.message);
-    return null;
-  }
-}
-
-async function transcribeAndStore(msg, filePath) {
-  if (!filePath) return;
-  const id = msg.id._serialized || msg.id;
-  const result = await asr.transcribe(filePath);
-  if (!result || !result.text) return;
-  const conf = result.confidence ?? 1;
-  if (conf < config.transcriptThreshold) return;
-  try {
-    await pool.query(
-      'INSERT INTO Transcripts(messageId, transcriptText, asrEngine) VALUES ($1, $2, $3)',
-      [id, result.text, config.asrEngine]
-    );
-    console.log('Stored transcript for', id);
-  } catch (err) {
-    console.error('Failed to store transcript', err.message);
-  }
-}
-
-async function logMessageDetails(msg) {
-  await storeMessage(msg);
-  const filePath = await storeMedia(msg);
-  await transcribeAndStore(msg, filePath);
-}
+// logMessageDetails is provided by messageLogger.js
 
 const messageQueue = [];
 let processingQueue = false;


### PR DESCRIPTION
## Summary
- document guidelines in `AGENTS.md`
- add detailed plan for history fetching
- allow running Postgres via Docker in README
- factor out message logging helpers
- create weekly history fetch logic
- invoke fetch logic on startup
- add table to track last fetch time

## Testing
- `node src/setupDb.js` *(fails: Error executing query)*
- `npm start` *(fails: PostgreSQL connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6861d497b31c83269f88a681e0cf2d29