### PR TITLE
Implement assistant job

### DIFF
--- a/docs/assistant-job-architecture.md
+++ b/docs/assistant-job-architecture.md
@@ -26,6 +26,14 @@ Tracks state for background jobs.
 - `lastError TEXT`
 - `retries INTEGER DEFAULT 0`
 
+## Configuration Flags
+
+Several options in `config.json` influence how the assistant and send jobs work:
+
+- `generateReplies` – when set to `false` the assistant job is disabled and no drafts are produced.
+- `approvalRequired` – if `true` Outbox rows stay in `draft` status until you approve them from the dashboard. Setting it to `false` lets the send job dispatch messages automatically.
+- `ignoreShortMessages` – skip reply generation for very short texts to avoid noise.
+
 ## Assistant Job (`assistantJob.js`)
 
 1. Query the `Messages` table for inbound messages that do not have an entry in `Outbox`.

--- a/src/assistantJob.js
+++ b/src/assistantJob.js
@@ -1,0 +1,86 @@
+const { pool } = require('./db');
+const { getHistory } = require('./history');
+const { draftReply } = require('./llm');
+const { getContactName } = require('./contacts');
+const config = require('./config');
+
+async function markJobStart(name) {
+  await pool.query(
+    `INSERT INTO JobStatus(job, lastStart) VALUES($1, NOW())
+     ON CONFLICT (job) DO UPDATE SET lastStart = EXCLUDED.lastStart`,
+    [name]
+  );
+}
+
+async function markJobEnd(name, err) {
+  await pool.query(
+    `UPDATE JobStatus SET lastEnd = NOW(), lastError = $2 WHERE job = $1`,
+    [name, err ? err.toString() : null]
+  );
+}
+
+async function getPendingMessages(limit = 20) {
+  const { rows } = await pool.query(
+    `SELECT m.id, m.chatId, m.timestamp,
+            COALESCE(t.transcriptText, m.body) AS text
+       FROM Messages m
+       LEFT JOIN Transcripts t ON m.id = t.messageId
+       WHERE m.fromMe = false
+         AND NOT EXISTS (
+           SELECT 1 FROM Outbox o WHERE o.sourceMessageId = m.id
+         )
+       ORDER BY m.timestamp ASC
+       LIMIT $1`,
+    [limit]
+  );
+  return rows;
+}
+
+async function processMessage(msg) {
+  if (config.ignoreShortMessages && msg.text && msg.text.trim().length < 2) {
+    return;
+  }
+  const historyRecords = await getHistory(msg.chatid, config.historyLimit);
+  const history = historyRecords.filter(r => r.id !== msg.id);
+  const contactName = (await getContactName(msg.chatid)) || 'Contact';
+  const draft = await draftReply(
+    config.persona,
+    history,
+    msg.text,
+    msg.timestamp,
+    contactName
+  );
+  if (!draft) return;
+  await pool.query(
+    `INSERT INTO Outbox(chatId, sourceMessageId, text, origin, status, priority)
+     VALUES ($1, $2, $3, 'ai', 'draft', 1)`,
+    [msg.chatid, msg.id, draft]
+  );
+}
+
+async function run(limit = 20) {
+  const jobName = 'assistant';
+  await markJobStart(jobName);
+  let error = null;
+  try {
+    if (!config.generateReplies) {
+      await markJobEnd(jobName, null);
+      return;
+    }
+    const pending = await getPendingMessages(limit);
+    for (const msg of pending) {
+      await processMessage(msg);
+    }
+  } catch (err) {
+    console.error('Assistant job error', err.message);
+    error = err;
+  }
+  await markJobEnd(jobName, error);
+  if (error) throw error;
+}
+
+if (require.main === module) {
+  run().then(() => process.exit(0)).catch(() => process.exit(1));
+}
+
+module.exports = { run };

--- a/src/setupDb.js
+++ b/src/setupDb.js
@@ -37,6 +37,24 @@ async function setup() {
       status TEXT,
       sentMessageId TEXT
     )`,
+    `CREATE TABLE IF NOT EXISTS Outbox (
+      id SERIAL PRIMARY KEY,
+      chatId TEXT,
+      sourceMessageId TEXT REFERENCES Messages(id),
+      text TEXT,
+      origin TEXT,
+      status TEXT,
+      priority INTEGER DEFAULT 1,
+      attempts INTEGER DEFAULT 0,
+      createdAt TIMESTAMPTZ DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS JobStatus (
+      job TEXT PRIMARY KEY,
+      lastStart TIMESTAMPTZ,
+      lastEnd TIMESTAMPTZ,
+      lastError TEXT,
+      retries INTEGER DEFAULT 0
+    )`,
     `CREATE TABLE IF NOT EXISTS VectorMeta (
       messageId TEXT PRIMARY KEY
     )`,


### PR DESCRIPTION
## Summary
- create Outbox and JobStatus tables
- add `assistantJob.js` script that drafts replies for new messages

## Testing
- `node src/setupDb.js` *(fails: Cannot find module 'pg')*
- `npm start` *(fails: Cannot find module 'dotenv')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692821a4b4832680ea20e93942d182