### PR TITLE
Fix chromadb default embed error

### DIFF
--- a/src/embeddingService.js
+++ b/src/embeddingService.js
@@ -13,4 +13,8 @@ function embed(text) {
   return vec;
 }
 
-module.exports = { embed };
+function embedMany(texts) {
+  return texts.map(embed);
+}
+
+module.exports = { embed, embedMany };

--- a/src/vectorDb.js
+++ b/src/vectorDb.js
@@ -1,5 +1,6 @@
 const { ChromaClient } = require('chromadb');
 const config = require('./config');
+const embedder = require('./embeddingService');
 
 const COLLECTION = 'messages';
 const chromaUrl = new URL(config.chromaUrl || 'http://localhost:8000');
@@ -12,7 +13,14 @@ let collection;
 
 async function ensureCollection() {
   if (collection) return;
-  collection = await chroma.getOrCreateCollection({ name: COLLECTION });
+  const embeddingFunction = {
+    name: 'hash-embedder',
+    generate: async texts => embedder.embedMany(texts)
+  };
+  collection = await chroma.getOrCreateCollection({
+    name: COLLECTION,
+    embeddingFunction
+  });
 }
 
 async function upsertVector(id, vector, metadata) {


### PR DESCRIPTION
## Summary
- add batch embedding helper
- specify custom embedding function when creating ChromaDB collection

## Testing
- `node src/setupDb.js` *(fails: Error executing query)*
- `npm start` *(fails to connect to PostgreSQL)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68699a2a8b748326a3c0a47dc54eb9b8