### PR TITLE
Limit assistant messages by days

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,5 +12,6 @@
   "generateReplies": false,
   "plugins": []
   ,"ignoreShortMessages": false,
+  "assistantLookbackDays": 2,
   "chromaUrl": "http://localhost:9090"
 }

--- a/docs/assistant-job-architecture.md
+++ b/docs/assistant-job-architecture.md
@@ -33,10 +33,11 @@ Several options in `config.json` influence how the assistant and send jobs work:
 - `generateReplies` – when set to `false` the assistant job is disabled and no drafts are produced.
 - `approvalRequired` – if `true` Outbox rows stay in `draft` status until you approve them from the dashboard. Setting it to `false` lets the send job dispatch messages automatically.
 - `ignoreShortMessages` – skip reply generation for very short texts to avoid noise.
+- `assistantLookbackDays` – only process messages from the last N days, newest first.
 
 ## Assistant Job (`assistantJob.js`)
 
-1. Query the `Messages` table for inbound messages that do not have an entry in `Outbox`.
+1. Query the `Messages` table for recent inbound messages (newest first) that do not have an entry in `Outbox`.
 2. For each message, gather recent history using existing helpers and call `draftReply` from `llm.js`.
 3. Insert the generated text into `Outbox` with `origin = 'ai'`,
    `status = 'draft'` and `priority = 1`.

--- a/docs/start-guide.md
+++ b/docs/start-guide.md
@@ -1,6 +1,6 @@
 # Getting Started with Enel
 
-This guide explains how to install and run the WhatsApp AI auto-responder.
+This guide explains how to install and run the WhatsApp AI auto-responder. The assistant job now prioritises the newest messages and ignores ones older than a configurable number of days.
 
 ## Installation
 
@@ -10,6 +10,7 @@ This guide explains how to install and run the WhatsApp AI auto-responder.
 4. Review `config.json` for non secret settings. Important fields include:
    - `whisperModel` – local Whisper model name (e.g. `base`).
    - `chromaUrl` – URL of the ChromaDB instance for vector search.
+   - `assistantLookbackDays` – how many days of messages the assistant job will consider.
 5. If PostgreSQL is not available locally, run one quickly with Docker:
    ```bash
    docker run --name enel-postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d postgres
@@ -36,5 +37,6 @@ This guide explains how to install and run the WhatsApp AI auto-responder.
 - ChromaDB must be running and reachable at the URL specified in `config.json`.
 - The app uses the official ChromaDB JavaScript client, so no manual HTTP configuration is required.
 - The Whisper CLI should be installed when using the local ASR engine.
+- The assistant job processes only messages from the last `assistantLookbackDays` days, newest first.
 
 

--- a/src/assistantJob.js
+++ b/src/assistantJob.js
@@ -26,12 +26,13 @@ async function getPendingMessages(limit = 20) {
        FROM Messages m
        LEFT JOIN Transcripts t ON m.id = t.messageId
        WHERE m.fromMe = false
+         AND m.timestamp >= NOW() - ($2 || ' days')::INTERVAL
          AND NOT EXISTS (
            SELECT 1 FROM Outbox o WHERE o.sourceMessageId = m.id
          )
-       ORDER BY m.timestamp ASC
+       ORDER BY m.timestamp DESC
        LIMIT $1`,
-    [limit]
+    [limit, config.assistantLookbackDays]
   );
   return rows;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ const defaults = {
   generateReplies: true,
   plugins: [],
   ignoreShortMessages: true,
+  assistantLookbackDays: 2,
   profileLlmEngine: 'local',
   profileLlmModel: 'llama3',
   whisperModel: 'base',


### PR DESCRIPTION
## Summary
- add `assistantLookbackDays` config option
- only process recent messages newest first in `assistantJob`
- document lookback window
- mention new job behaviour in the start guide

## Testing
- `node src/setupDb.js` *(fails: Error executing query)*
- `npm start` *(fails: ECONNREFUSED: connect)*

------
https://chatgpt.com/codex/tasks/task_e_6869f2e0bd308326bd7ab216316c62f8