### PR TITLE
Add follow-up job and profile dashboard

### DIFF
--- a/docs/follow-up-job.md
+++ b/docs/follow-up-job.md
@@ -1,0 +1,16 @@
+# Follow Up Job
+
+This background task scans recent messages to suggest conversations that need attention.
+
+Two simple rules are applied:
+
+1. **Unanswered questions** – if a contact sent a message containing a `?` and no reply was sent afterwards, the job records a follow up.
+2. **Catch ups** – contacts that have not exchanged any message for 30 days are also listed.
+
+Results are stored in the `FollowUps` table and shown on the dashboard. Run the job manually with:
+
+```
+node src/followUpJob.js
+```
+
+It is also included in `masterJob.js` so scheduled runs can call that script once per day.

--- a/docs/profile-management.md
+++ b/docs/profile-management.md
@@ -1,0 +1,7 @@
+# Web Profile Management
+
+The dashboard includes a simple page to view and edit contact profiles.
+Open `/profiles.html` and select a contact from the list.
+Their current profile text will load in a text area and can be updated.
+
+Profiles are stored in the `Contacts` table and can also be generated automatically with `node src/profileJob.js`.

--- a/public/app.js
+++ b/public/app.js
@@ -83,12 +83,26 @@ async function fetchJobs() {
   });
 }
 
+async function fetchFollowUps() {
+  const res = await fetch('/followups');
+  const items = await res.json();
+  const container = document.getElementById('followups');
+  container.innerHTML = '';
+  items.forEach(f => {
+    const div = document.createElement('div');
+    const name = f.name || f.contactid;
+    div.textContent = `${name} (${f.reason})`;
+    container.appendChild(div);
+  });
+}
+
 const socket = io();
 socket.on('refresh', () => {
   fetchDrafts();
   fetchSent();
   fetchOutbox();
   fetchJobs();
+  fetchFollowUps();
 });
 
 fetchDrafts();
@@ -96,4 +110,5 @@ fetchAsrStatus();
 fetchSent();
 fetchOutbox();
 fetchJobs();
+fetchFollowUps();
 

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,9 @@
   <span id="asrStatus"></span>
   <h2>Jobs</h2>
   <div id="jobs"></div>
+  <h2>Follow Ups</h2>
+  <div id="followups"></div>
+  <p><a href="/profiles.html">Manage Contact Profiles</a></p>
   <h2>Messages Sent Today</h2>
   <div id="sent"></div>
   <script src="/socket.io/socket.io.js"></script>

--- a/public/profiles.html
+++ b/public/profiles.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Contact Profiles</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    #contactList { width: 200px; float: left; margin-right: 20px; }
+    textarea { width: 400px; height: 200px; }
+  </style>
+</head>
+<body>
+  <h1>Contact Profiles</h1>
+  <div id="contactList"></div>
+  <div>
+    <h2 id="contactName"></h2>
+    <textarea id="profileText"></textarea><br>
+    <button id="saveBtn">Save</button>
+  </div>
+  <script src="profiles.js"></script>
+</body>
+</html>

--- a/public/profiles.js
+++ b/public/profiles.js
@@ -1,0 +1,38 @@
+async function loadContacts() {
+  const res = await fetch('/contacts');
+  const contacts = await res.json();
+  const list = document.getElementById('contactList');
+  list.innerHTML = '';
+  contacts.forEach(c => {
+    const div = document.createElement('div');
+    div.textContent = c.name || c.id;
+    div.style.cursor = 'pointer';
+    div.onclick = () => selectContact(c.id, c.name);
+    list.appendChild(div);
+  });
+}
+
+let currentId = null;
+
+async function selectContact(id, name) {
+  const res = await fetch('/contacts/' + id);
+  const data = await res.json();
+  currentId = id;
+  document.getElementById('contactName').textContent = name || id;
+  document.getElementById('profileText').value = data.profile || '';
+}
+
+async function saveProfile() {
+  if (!currentId) return;
+  const text = document.getElementById('profileText').value;
+  await fetch('/contacts/' + currentId + '/profile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ profile: text })
+  });
+  alert('Saved');
+}
+
+document.getElementById('saveBtn').onclick = saveProfile;
+
+loadContacts();

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -102,6 +102,36 @@ function startDashboard(client) {
     res.json(rows);
   });
 
+  app.get('/followups', async (req, res) => {
+    const { rows } = await pool.query(
+      `SELECT f.id, f.reason, f.messageId, f.createdAt, c.name, f.contactId
+         FROM FollowUps f
+         LEFT JOIN Contacts c ON f.contactId = c.id
+        WHERE f.resolved = false
+        ORDER BY f.createdAt DESC`
+    );
+    res.json(rows);
+  });
+
+  app.get('/contacts', async (req, res) => {
+    const { rows } = await pool.query('SELECT id, name, profile FROM Contacts ORDER BY name');
+    res.json(rows);
+  });
+
+  app.get('/contacts/:id', async (req, res) => {
+    const { id } = req.params;
+    const { rows } = await pool.query('SELECT id, name, profile FROM Contacts WHERE id=$1', [id]);
+    if (!rows.length) return res.status(404).send('Not found');
+    res.json(rows[0]);
+  });
+
+  app.post('/contacts/:id/profile', async (req, res) => {
+    const { id } = req.params;
+    const { profile } = req.body || {};
+    await pool.query('UPDATE Contacts SET profile=$2 WHERE id=$1', [id, profile]);
+    res.json({ ok: true });
+  });
+
   server.listen(3000, () => console.log('Dashboard running on http://localhost:3000'));
 }
 

--- a/src/followUpJob.js
+++ b/src/followUpJob.js
@@ -1,0 +1,86 @@
+const { pool } = require('./db');
+
+async function markJobStart(name) {
+  await pool.query(
+    `INSERT INTO JobStatus(job, lastStart) VALUES($1, NOW())
+     ON CONFLICT (job) DO UPDATE SET lastStart = EXCLUDED.lastStart`,
+    [name]
+  );
+}
+
+async function markJobEnd(name, err) {
+  await pool.query(
+    `UPDATE JobStatus SET lastEnd = NOW(), lastError = $2 WHERE job = $1`,
+    [name, err ? err.toString() : null]
+  );
+}
+
+async function storeFollowUp(contactId, reason, messageId) {
+  await pool.query(
+    `INSERT INTO FollowUps(contactId, reason, messageId)
+     VALUES ($1, $2, $3)`,
+    [contactId, reason, messageId]
+  );
+}
+
+async function getUnansweredQuestions(days = 2) {
+  const cutoff = Math.floor(Date.now() / 1000) - days * 86400;
+  const { rows } = await pool.query(
+    `SELECT m.id, m.chatId, m.body
+       FROM Messages m
+      WHERE m.fromMe = false
+        AND m.body LIKE '%?%'
+        AND m.timestamp >= $1
+        AND NOT EXISTS (
+          SELECT 1 FROM Messages m2
+           WHERE m2.chatId = m.chatId
+             AND m2.fromMe = true
+             AND m2.timestamp > m.timestamp
+        )`,
+    [cutoff]
+  );
+  return rows;
+}
+
+async function getStaleContacts(days = 30) {
+  const cutoff = Math.floor(Date.now() / 1000) - days * 86400;
+  const { rows } = await pool.query(
+    `SELECT chatId, MAX(timestamp) AS last_time
+       FROM Messages
+       GROUP BY chatId
+       HAVING MAX(timestamp) < $1`,
+    [cutoff]
+  );
+  return rows.map(r => ({ chatId: r.chatid, last: r.last_time }));
+}
+
+async function processFollowUps() {
+  const questions = await getUnansweredQuestions();
+  for (const q of questions) {
+    await storeFollowUp(q.chatid, 'question', q.id);
+  }
+  const stale = await getStaleContacts();
+  for (const s of stale) {
+    await storeFollowUp(s.chatid, 'catch_up', null);
+  }
+}
+
+async function run() {
+  const jobName = 'followUp';
+  await markJobStart(jobName);
+  let error = null;
+  try {
+    await processFollowUps();
+  } catch (err) {
+    console.error('Follow-up job error', err.message);
+    error = err;
+  }
+  await markJobEnd(jobName, error);
+  if (error) throw error;
+}
+
+if (require.main === module) {
+  run().then(() => process.exit(0)).catch(() => process.exit(1));
+}
+
+module.exports = { run };

--- a/src/masterJob.js
+++ b/src/masterJob.js
@@ -3,12 +3,14 @@ const setupDb = require('./setupDb');
 const initWhatsApp = require('./waClient');
 const assistantJob = require('./assistantJob');
 const sendQueueJob = require('./sendQueueJob');
+const followUpJob = require('./followUpJob');
 
 async function run() {
   await db.testConnection();
   await setupDb();
   //const client = await initWhatsApp();
   await assistantJob.run();
+  await followUpJob.run();
   //await sendQueueJob.run(client);
 }
 

--- a/src/setupDb.js
+++ b/src/setupDb.js
@@ -56,6 +56,14 @@ async function setup() {
       lastError TEXT,
       retries INTEGER DEFAULT 0
     )`,
+    `CREATE TABLE IF NOT EXISTS FollowUps (
+      id SERIAL PRIMARY KEY,
+      contactId TEXT REFERENCES Contacts(id),
+      reason TEXT,
+      messageId TEXT,
+      createdAt TIMESTAMPTZ DEFAULT now(),
+      resolved BOOLEAN DEFAULT false
+    )`,
     `CREATE TABLE IF NOT EXISTS VectorMeta (
       messageId TEXT PRIMARY KEY
     )`,


### PR DESCRIPTION
## Summary
- track follow-up suggestions in new `FollowUps` table
- add follow-up background job
- expose follow-ups and contacts on the dashboard
- simple page to edit contact profiles
- document the follow-up job and profile management

## Testing
- `node src/setupDb.js` *(fails: Error executing query)*
- `npm start` *(fails: PostgreSQL connection error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ac7a4896c8326affe9539557947f5