### PR TITLE
Add Google Generative API support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 DATABASE_URL=postgres://user:password@localhost:5432/enel
+OPENAI_API_KEY=your-openai-key
+GEMINI_API_KEY=your-gemini-key
+

--- a/docs/google-llm.md
+++ b/docs/google-llm.md
@@ -1,0 +1,8 @@
+# Using Google Generative AI
+
+The application can now generate message drafts with Google's Gemini model. To enable it:
+
+1. Set `llmEngine` to `"google"` in `config.json`.
+2. Provide your API key in the `GEMINI_API_KEY` environment variable.
+
+When this engine is selected, the prompt is sent to the Generative Language API and the returned text is used as the draft reply.

--- a/docs/start-guide.md
+++ b/docs/start-guide.md
@@ -11,6 +11,7 @@ This guide explains how to install and run the WhatsApp AI auto-responder. The a
    - `whisperModel` – local Whisper model name (e.g. `base`).
    - `chromaUrl` – URL of the ChromaDB instance for vector search.
    - `assistantLookbackDays` – how many days of messages the assistant job will consider.
+   - `llmEngine` – set to `local`, `pro`, or `google` to choose the LLM provider.
 5. If PostgreSQL is not available locally, run one quickly with Docker:
    ```bash
    docker run --name enel-postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d postgres


### PR DESCRIPTION
## Summary
- extend LLM module to support Google Generative API
- allow using either OpenAI (`pro`) or Google (`google`) models
- update profile LLM to match new provider options
- document the new option and API keys

## Testing
- `npm test`
- `node src/setupDb.js` *(fails: Error executing query)*
- `npm start` *(fails: PostgreSQL connection error)*

------
https://chatgpt.com/codex/tasks/task_e_686acda762808326aeb1ecc4fdd3fd05